### PR TITLE
Minor typos in soundness proof

### DIFF
--- a/content/first-order-logic/sequent-calculus/soundness.tex
+++ b/content/first-order-logic/sequent-calculus/soundness.tex
@@ -222,9 +222,9 @@ $\lor$~left, $\land$~right, and $\lif$~left.
 \item The last inference is $\lor$~left: Exercise.
 \item The last inference is $\lif$~left.  The premises are $\Gamma
   \Sequent \Delta'$ and $\Gamma' \Sequent \Delta$, where $!A \in
-  \Delta'$ an $!B \in \Gamma'$.  By induction hypothesis, both are
+  \Delta'$ and $!B \in \Gamma'$.  By induction hypothesis, both are
   valid.  Consider a !!{structure}~$\Struct M$.  We have two cases:
-  (a) $\Sat/{M}{!A \lif !B}$ or (b) $\Sat{M}{!A \lif !B}$.  In case
+  (a) $\Sat{M}{!A \lif !B}$ or (b) $\Sat/{M}{!A \lif !B}$.  In case
   (a), either $\Sat/{M}{!A}$ or $\Sat{M}{!B}$.  In the former case, in
   order for $\Struct M$ to satisfy $\Gamma \Sequent \Delta'$, it must
   already satisfy $\Gamma \Sequent \Delta' \setminus \{!A\}$.  In the


### PR DESCRIPTION
Three minor typos in proof of soundness. Corrected.
